### PR TITLE
빌드 시 AD_MOB_APP_ID가 빈값이 되는 문제 해결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,10 +41,10 @@ android {
 
     buildTypes {
         debug {
-            manifestPlaceholders["AD_MOB_APP_ID"] = "ca-app-pub-3940256099942544~3347511713"
+            resValue("string", "AD_MOB_APP_ID", "ca-app-pub-3940256099942544~3347511713")
         }
         release {
-            manifestPlaceholders["AD_MOB_APP_ID"] = adMobAppId
+            resValue("string", "AD_MOB_APP_ID", adMobAppId)
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,7 +88,7 @@
         
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="${AD_MOB_APP_ID}"  />
+            android:value="@string/AD_MOB_APP_ID"  />
 
     </application>
 


### PR DESCRIPTION
resolved: #86 

# 작업 내용
- 빌드 시 AD_MOB_APP_ID가 빈값이 되는 문제 해결
