### PR TITLE
내 번호 다중 추가 및 전체 선택 기능

### DIFF
--- a/core/data/src/main/java/junjange/core/data/datasource/LotteryRoomDataSource.kt
+++ b/core/data/src/main/java/junjange/core/data/datasource/LotteryRoomDataSource.kt
@@ -16,4 +16,6 @@ interface LotteryRoomDataSource {
         round: Int,
         id: Long,
     ): Result<Unit>
+
+    suspend fun deleteAllLottery(): Result<Unit>
 }

--- a/core/data/src/main/java/junjange/core/data/datasource/PensionLotteryRoomDataSource.kt
+++ b/core/data/src/main/java/junjange/core/data/datasource/PensionLotteryRoomDataSource.kt
@@ -16,4 +16,6 @@ interface PensionLotteryRoomDataSource {
         round: Int,
         id: Long,
     ): Result<Unit>
+
+    suspend fun deleteAllPensionLottery(): Result<Unit>
 }

--- a/core/data/src/main/java/junjange/core/data/repository/LotteryRepositoryImpl.kt
+++ b/core/data/src/main/java/junjange/core/data/repository/LotteryRepositoryImpl.kt
@@ -82,6 +82,8 @@ internal class LotteryRepositoryImpl
             id: Long,
         ): Result<Unit> = lotteryRoomDataSource.deleteLotteryByRoundAndId(round = round, id = id)
 
+        override suspend fun deleteAllLottery(): Result<Unit> = lotteryRoomDataSource.deleteAllLottery()
+
         private suspend fun getWinningLotteries(
             pagedRounds: List<Int>,
             lotteries: List<LotteryNumberDto>,

--- a/core/data/src/main/java/junjange/core/data/repository/PensionLotteryRepositoryImpl.kt
+++ b/core/data/src/main/java/junjange/core/data/repository/PensionLotteryRepositoryImpl.kt
@@ -169,6 +169,8 @@ internal class PensionLotteryRepositoryImpl
                 id = id,
             )
 
+        override suspend fun deleteAllPensionLottery(): Result<Unit> = pensionLotteryRoomDataSource.deleteAllPensionLottery()
+
         private suspend fun getWinningPensionLotteries(
             pagedRounds: List<Int>,
             pensionLotteries: List<PensionLotteryNumberDto>,

--- a/core/domain/src/main/java/junjange/core/domain/repository/LotteryRepository.kt
+++ b/core/domain/src/main/java/junjange/core/domain/repository/LotteryRepository.kt
@@ -44,4 +44,6 @@ interface LotteryRepository {
         round: Int,
         id: Long,
     ): Result<Unit>
+
+    suspend fun deleteAllLottery(): Result<Unit>
 }

--- a/core/domain/src/main/java/junjange/core/domain/repository/PensionLotteryRepository.kt
+++ b/core/domain/src/main/java/junjange/core/domain/repository/PensionLotteryRepository.kt
@@ -46,4 +46,6 @@ interface PensionLotteryRepository {
         round: Int,
         id: Long,
     ): Result<Unit>
+
+    suspend fun deleteAllPensionLottery(): Result<Unit>
 }

--- a/core/domain/src/main/java/junjange/core/domain/usecase/DeleteAllLotteryUseCase.kt
+++ b/core/domain/src/main/java/junjange/core/domain/usecase/DeleteAllLotteryUseCase.kt
@@ -1,0 +1,12 @@
+package junjange.core.domain.usecase
+
+import junjange.core.domain.repository.LotteryRepository
+import javax.inject.Inject
+
+class DeleteAllLotteryUseCase
+    @Inject
+    constructor(
+        private val repository: LotteryRepository,
+    ) {
+        suspend operator fun invoke(): Result<Unit> = repository.deleteAllLottery()
+    }

--- a/core/domain/src/main/java/junjange/core/domain/usecase/DeleteAllPensionLotteryUseCase.kt
+++ b/core/domain/src/main/java/junjange/core/domain/usecase/DeleteAllPensionLotteryUseCase.kt
@@ -1,0 +1,12 @@
+package junjange.core.domain.usecase
+
+import junjange.core.domain.repository.PensionLotteryRepository
+import javax.inject.Inject
+
+class DeleteAllPensionLotteryUseCase
+    @Inject
+    constructor(
+        private val repository: PensionLotteryRepository,
+    ) {
+        suspend operator fun invoke(): Result<Unit> = repository.deleteAllPensionLottery()
+    }

--- a/core/local/src/main/java/junjange/core/local/dao/LotteryDao.kt
+++ b/core/local/src/main/java/junjange/core/local/dao/LotteryDao.kt
@@ -25,4 +25,7 @@ interface LotteryDao {
         round: Int,
         id: Long,
     )
+
+    @Query("DELETE FROM lottery")
+    suspend fun deleteAllLottery()
 }

--- a/core/local/src/main/java/junjange/core/local/dao/PensionLotteryDao.kt
+++ b/core/local/src/main/java/junjange/core/local/dao/PensionLotteryDao.kt
@@ -25,4 +25,7 @@ interface PensionLotteryDao {
         round: Int,
         id: Long,
     )
+
+    @Query("DELETE FROM pension_lottery")
+    suspend fun deleteAllPensionLottery()
 }

--- a/core/local/src/main/java/junjange/core/local/datasource/LotteryRoomDataSourceImpl.kt
+++ b/core/local/src/main/java/junjange/core/local/datasource/LotteryRoomDataSourceImpl.kt
@@ -27,4 +27,6 @@ internal class LotteryRoomDataSourceImpl
             round: Int,
             id: Long,
         ): Result<Unit> = runCatching { dao.deleteLotteryByRoundAndId(round = round, id = id) }
+
+        override suspend fun deleteAllLottery(): Result<Unit> = runCatching { dao.deleteAllLottery() }
     }

--- a/core/local/src/main/java/junjange/core/local/datasource/PensionLotteryRoomDataSourceImpl.kt
+++ b/core/local/src/main/java/junjange/core/local/datasource/PensionLotteryRoomDataSourceImpl.kt
@@ -27,4 +27,6 @@ internal class PensionLotteryRoomDataSourceImpl
             round: Int,
             id: Long,
         ): Result<Unit> = runCatching { dao.deletePensionLotteryByRoundAndId(round = round, id = id) }
+
+        override suspend fun deleteAllPensionLottery(): Result<Unit> = runCatching { dao.deleteAllPensionLottery() }
     }

--- a/core/ui/src/main/java/junjange/core/ui/component/LottoNumberEntry.kt
+++ b/core/ui/src/main/java/junjange/core/ui/component/LottoNumberEntry.kt
@@ -1,19 +1,34 @@
 package junjange.core.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,54 +40,113 @@ import androidx.core.text.isDigitsOnly
 import junjange.core.designsystem.theme.LottoTheme
 import junjange.core.ui.R
 
+private class LottoEntryGame {
+    val numbers = mutableStateListOf("", "", "", "", "", "")
+    val focusRequesters = List(6) { FocusRequester() }
+}
+
 @Composable
 fun LottoNumberEntry(
-    onSubmit: (List<String>) -> Unit,
+    onSubmit: (List<List<String>>) -> Unit,
     onDuplicateLottery: () -> Unit,
 ) {
-    val focusRequesters = List(6) { FocusRequester() }
-    val lottery = remember { mutableStateListOf("", "", "", "", "", "") }
-    val enabled = lottery.all { it.isNotBlank() }
+    val games = remember { mutableStateListOf(LottoEntryGame()) }
+    val enabled = games.all { game -> game.numbers.all { it.isNotBlank() } }
+    var previousGameCount by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(Unit) {
-        focusRequesters[0].requestFocus()
+    LaunchedEffect(games.size) {
+        if (games.size > previousGameCount) {
+            games.last().focusRequesters[0].requestFocus()
+        }
+        previousGameCount = games.size
     }
 
-    Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+    Column(
+        modifier =
+            Modifier
+                .padding(horizontal = 20.dp)
+                .verticalScroll(rememberScrollState()),
+    ) {
         Text(stringResource(R.string.enter_lotto_numbers), style = LottoTheme.typography.headline3)
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement =
-                Arrangement.spacedBy(
-                    16.dp,
-                    Alignment.CenterHorizontally,
-                ),
-        ) {
-            for (i in lottery.indices) {
-                LottoBallTextField(
-                    value = lottery[i],
-                    onValueChange = { newValue ->
-                        if (newValue.isBlank() || (newValue.isDigitsOnly() && newValue.toIntOrNull() in 1..45)) {
-                            lottery[i] = newValue
-                        }
-                        if ((lottery[i].toIntOrNull() in 5..9 || lottery[i].length == 2) && i < 5) {
-                            focusRequesters.getOrNull(i + 1)?.requestFocus()
-                        }
-                    },
-                    keyboardActions =
-                        KeyboardActions(
-                            onDone = {
-                                if (i < 5) {
-                                    focusRequesters.getOrNull(i + 1)?.requestFocus()
+        games.forEachIndexed { gameIndex, game ->
+            key(game) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement =
+                        Arrangement.spacedBy(
+                            8.dp,
+                            Alignment.CenterHorizontally,
+                        ),
+                ) {
+                    for (i in game.numbers.indices) {
+                        LottoBallTextField(
+                            value = game.numbers[i],
+                            onValueChange = { newValue ->
+                                if (newValue.isBlank() || (newValue.isDigitsOnly() && newValue.toIntOrNull() in 1..45)) {
+                                    game.numbers[i] = newValue
+                                }
+                                if ((game.numbers[i].toIntOrNull() in 5..9 || game.numbers[i].length == 2) && i < 5) {
+                                    game.focusRequesters.getOrNull(i + 1)?.requestFocus()
                                 }
                             },
-                        ),
-                    modifier = Modifier.focusRequester(focusRequesters[i]),
-                )
+                            keyboardActions =
+                                KeyboardActions(
+                                    onDone = {
+                                        if (i < 5) {
+                                            game.focusRequesters.getOrNull(i + 1)?.requestFocus()
+                                        }
+                                    },
+                                ),
+                            modifier = Modifier.focusRequester(game.focusRequesters[i]),
+                        )
+                    }
+
+                    Box(modifier = Modifier.size(24.dp)) {
+                        if (games.size > 1) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.remove_number),
+                                tint = LottoTheme.colors.gray400,
+                                modifier =
+                                    Modifier
+                                        .size(24.dp)
+                                        .clip(CircleShape)
+                                        .clickable { games.removeAt(gameIndex) },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
             }
+        }
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(shape = RoundedCornerShape(8.dp))
+                    .clickable { games.add(LottoEntryGame()) }
+                    .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = LottoTheme.colors.green,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.add_number),
+                style = LottoTheme.typography.body3,
+                color = LottoTheme.colors.green,
+            )
         }
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -88,8 +162,8 @@ fun LottoNumberEntry(
             isEnabled = enabled,
             onClick = {
                 if (enabled) {
-                    if (lottery.toSet().size == 6) {
-                        onSubmit(lottery.toList())
+                    if (games.all { it.numbers.toSet().size == 6 }) {
+                        onSubmit(games.map { it.numbers.toList() })
                     } else {
                         onDuplicateLottery()
                     }

--- a/core/ui/src/main/java/junjange/core/ui/component/PensionLotteryNumberEntry.kt
+++ b/core/ui/src/main/java/junjange/core/ui/component/PensionLotteryNumberEntry.kt
@@ -1,19 +1,34 @@
 package junjange.core.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,20 +41,33 @@ import junjange.core.designsystem.theme.LottoTheme
 import junjange.core.designsystem.theme.lotteryColors
 import junjange.core.ui.R
 
+private class PensionLotteryEntryGame {
+    val numbers = mutableStateListOf("", "", "", "", "", "", "")
+    val focusRequesters = List(7) { FocusRequester() }
+}
+
 @Composable
 fun PensionLotteryNumberEntry(
-    onSubmit: (List<String>) -> Unit,
+    onSubmit: (List<List<String>>) -> Unit,
     onInvalidGroup: () -> Unit,
 ) {
-    val focusRequesters = List(7) { FocusRequester() }
-    val pensionLottery = remember { mutableStateListOf("", "", "", "", "", "", "") }
-    val enabled = pensionLottery.all { it.isNotBlank() }
+    val games = remember { mutableStateListOf(PensionLotteryEntryGame()) }
+    val enabled = games.all { game -> game.numbers.all { it.isNotBlank() } }
+    var previousGameCount by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(Unit) {
-        focusRequesters[0].requestFocus()
+    LaunchedEffect(games.size) {
+        if (games.size > previousGameCount) {
+            games.last().focusRequesters[0].requestFocus()
+        }
+        previousGameCount = games.size
     }
 
-    Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+    Column(
+        modifier =
+            Modifier
+                .padding(horizontal = 20.dp)
+                .verticalScroll(rememberScrollState()),
+    ) {
         Text(
             stringResource(R.string.enter_pension_lottery_number),
             style = LottoTheme.typography.headline3,
@@ -47,44 +75,90 @@ fun PensionLotteryNumberEntry(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement =
-                Arrangement.spacedBy(
-                    12.dp,
-                    Alignment.CenterHorizontally,
-                ),
-        ) {
-            for (i in pensionLottery.indices) {
-                if (i == 1) {
-                    Text(
-                        text = stringResource(id = R.string.group_title),
-                        style = LottoTheme.typography.headline3,
-                    )
-                }
+        games.forEachIndexed { gameIndex, game ->
+            key(game) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement =
+                        Arrangement.spacedBy(
+                            8.dp,
+                            Alignment.CenterHorizontally,
+                        ),
+                ) {
+                    for (i in game.numbers.indices) {
+                        if (i == 1) {
+                            Text(
+                                text = stringResource(id = R.string.group_title),
+                                style = LottoTheme.typography.headline3,
+                            )
+                        }
 
-                PensionLotteryBallTextField(
-                    value = pensionLottery[i],
-                    onValueChange = { newValue ->
-                        if (newValue.isBlank() || (newValue.isDigitsOnly() && newValue.toIntOrNull() in 0..9)) {
-                            pensionLottery[i] = newValue
-                        }
-                        if (pensionLottery[i].length == 1 && i < 6) {
-                            focusRequesters.getOrNull(i + 1)?.requestFocus()
-                        }
-                    },
-                    keyboardActions =
-                        KeyboardActions(
-                            onDone = {
-                                if (i < 6) {
-                                    focusRequesters.getOrNull(i + 1)?.requestFocus()
+                        PensionLotteryBallTextField(
+                            value = game.numbers[i],
+                            onValueChange = { newValue ->
+                                if (newValue.isBlank() || (newValue.isDigitsOnly() && newValue.toIntOrNull() in 0..9)) {
+                                    game.numbers[i] = newValue
+                                }
+                                if (game.numbers[i].length == 1 && i < 6) {
+                                    game.focusRequesters.getOrNull(i + 1)?.requestFocus()
                                 }
                             },
-                        ),
-                    color = lotteryColors[i],
-                    modifier = Modifier.focusRequester(focusRequesters[i]),
-                )
+                            keyboardActions =
+                                KeyboardActions(
+                                    onDone = {
+                                        if (i < 6) {
+                                            game.focusRequesters.getOrNull(i + 1)?.requestFocus()
+                                        }
+                                    },
+                                ),
+                            color = lotteryColors[i],
+                            modifier = Modifier.focusRequester(game.focusRequesters[i]),
+                        )
+                    }
+
+                    Box(modifier = Modifier.size(24.dp)) {
+                        if (games.size > 1) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.remove_number),
+                                tint = LottoTheme.colors.gray400,
+                                modifier =
+                                    Modifier
+                                        .size(24.dp)
+                                        .clip(CircleShape)
+                                        .clickable { games.removeAt(gameIndex) },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
             }
+        }
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(shape = RoundedCornerShape(8.dp))
+                    .clickable { games.add(PensionLotteryEntryGame()) }
+                    .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = null,
+                tint = LottoTheme.colors.green,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.add_number),
+                style = LottoTheme.typography.body3,
+                color = LottoTheme.colors.green,
+            )
         }
 
         Spacer(modifier = Modifier.height(20.dp))
@@ -100,8 +174,8 @@ fun PensionLotteryNumberEntry(
             isEnabled = enabled,
             onClick = {
                 if (enabled) {
-                    if (pensionLottery.first().toInt() in 1..5) {
-                        onSubmit(pensionLottery.toList())
+                    if (games.all { it.numbers.first().toInt() in 1..5 }) {
+                        onSubmit(games.map { it.numbers.toList() })
                     } else {
                         onInvalidGroup()
                     }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
 
     <string name="create_title">생성</string>
     <string name="group_title">조</string>
+    <string name="add_number">번호 추가</string>
+    <string name="remove_number">번호 삭제</string>
 
     <string name="winning_numbers_title">당첨번호</string>
     <string name="bonus_numbers_title">보너스</string>

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberContract.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberContract.kt
@@ -56,6 +56,10 @@ sealed interface MyNumberContract {
         data class DeletePensionLottery(
             val userRoundIds: List<UserRoundId>,
         ) : Event
+
+        data object DeleteAllLottery : Event
+
+        data object DeleteAllPensionLottery : Event
     }
 
     sealed interface Effect {

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberContract.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberContract.kt
@@ -29,12 +29,12 @@ sealed interface MyNumberContract {
 
         data object LoadPensionLottery : Event
 
-        data class InsertLottery(
-            val lottery: List<String>,
+        data class InsertLotteries(
+            val lotteries: List<List<String>>,
         ) : Event
 
-        data class InsertPensionLottery(
-            val pensionLottery: List<String>,
+        data class InsertPensionLotteries(
+            val pensionLotteries: List<List<String>>,
         ) : Event
 
         data class LottoTextOfImage(

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberScreen.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberScreen.kt
@@ -221,9 +221,9 @@ fun MyNumberScreen(
         snackbarHostState = snackbarHostState,
         onGalleryClicked = { viewModel.event(PickedImage) },
         onDeleteClicked = { deleteMode -> isDeleteMode = deleteMode },
-        onLotterySaveClicked = { lottery -> viewModel.event(InsertLottery(lottery)) },
-        onPensionLotterySaveClicked = { pensionLottery ->
-            viewModel.event(InsertPensionLottery(pensionLottery))
+        onLotterySaveClicked = { lotteries -> viewModel.event(InsertLotteries(lotteries)) },
+        onPensionLotterySaveClicked = { pensionLotteries ->
+            viewModel.event(InsertPensionLotteries(pensionLotteries))
         },
         checkedLottery = { lotteryGetNumber ->
             if (deleteLottery.contains(lotteryGetNumber)) {
@@ -268,8 +268,8 @@ fun MyNumberContent(
     modifier: Modifier = Modifier,
     onGalleryClicked: () -> Unit,
     onDeleteClicked: (isDeleteMode: Boolean) -> Unit,
-    onLotterySaveClicked: (List<String>) -> Unit,
-    onPensionLotterySaveClicked: (List<String>) -> Unit,
+    onLotterySaveClicked: (List<List<String>>) -> Unit,
+    onPensionLotterySaveClicked: (List<List<String>>) -> Unit,
     checkedLottery: (userRoundId: UserRoundId) -> Unit,
     checkedPensionLottery: (userRoundId: UserRoundId) -> Unit,
     onDeleteLotteryClicked: () -> Unit,
@@ -370,9 +370,9 @@ fun MyNumberContent(
                     when (pagerState.currentPage) {
                         0 ->
                             LottoNumberEntry(
-                                onSubmit = { lottery ->
+                                onSubmit = { lotteries ->
                                     isSheetOpen = false
-                                    onLotterySaveClicked(lottery)
+                                    onLotterySaveClicked(lotteries)
                                 },
                                 onDuplicateLottery = {
                                     context.showToast(R.string.lotto_duplicate_error)
@@ -381,10 +381,9 @@ fun MyNumberContent(
 
                         1 ->
                             PensionLotteryNumberEntry(
-                                onSubmit = { pensionLottery ->
+                                onSubmit = { pensionLotteries ->
                                     isSheetOpen = false
-                                    onPensionLotterySaveClicked(pensionLottery)
-//                                    context.showToast(R.string.pension_lottery_number_submitted)
+                                    onPensionLotterySaveClicked(pensionLotteries)
                                 },
                                 onInvalidGroup = {
                                     context.showToast(R.string.pension_lottery_invalid_group)

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberScreen.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberScreen.kt
@@ -145,6 +145,7 @@ fun MyNumberScreen(
     val lotteryGetContent = state.lotteryFlow.collectAsLazyPagingItems()
     val pensionLotteryGetContent = state.pensionLotteryFlow.collectAsLazyPagingItems()
     var isDeleteMode by remember { mutableStateOf(false) }
+    var isAllSelected by remember { mutableStateOf(false) }
 
     val deleteLottery =
         rememberSaveable(
@@ -194,14 +195,24 @@ fun MyNumberScreen(
         LotteryDeleteDialog(
             onDismiss = { viewModel.event(ShowDialog(isDialogShowing = false)) },
             okClick = {
-                if (deleteLottery.isNotEmpty()) {
-                    viewModel.event(DeleteLottery(deleteLottery.toList()))
+                if (isAllSelected) {
+                    when (pagerState.currentPage) {
+                        0 -> viewModel.event(DeleteAllLottery)
+                        1 -> viewModel.event(DeleteAllPensionLottery)
+                    }
                     deleteLottery.clear()
-                }
-
-                if (deletePensionLottery.isNotEmpty()) {
-                    viewModel.event(DeletePensionLottery(deletePensionLottery.toList()))
                     deletePensionLottery.clear()
+                    isAllSelected = false
+                } else {
+                    if (deleteLottery.isNotEmpty()) {
+                        viewModel.event(DeleteLottery(deleteLottery.toList()))
+                        deleteLottery.clear()
+                    }
+
+                    if (deletePensionLottery.isNotEmpty()) {
+                        viewModel.event(DeletePensionLottery(deletePensionLottery.toList()))
+                        deletePensionLottery.clear()
+                    }
                 }
 
                 viewModel.event(ShowDialog(isDialogShowing = false))
@@ -226,6 +237,7 @@ fun MyNumberScreen(
             viewModel.event(InsertPensionLotteries(pensionLotteries))
         },
         checkedLottery = { lotteryGetNumber ->
+            isAllSelected = false
             if (deleteLottery.contains(lotteryGetNumber)) {
                 deleteLottery.remove(lotteryGetNumber)
             } else {
@@ -233,6 +245,7 @@ fun MyNumberScreen(
             }
         },
         checkedPensionLottery = { pensionLotteryNumbers ->
+            isAllSelected = false
             if (deletePensionLottery.contains(pensionLotteryNumbers)) {
                 deletePensionLottery.remove(pensionLotteryNumbers)
             } else {
@@ -246,8 +259,38 @@ fun MyNumberScreen(
                 context.showToast(context.getString(R.string.empty_delete_list))
             }
         },
+        isAllSelected = isAllSelected,
+        onSelectAllClicked = {
+            if (isAllSelected) {
+                deleteLottery.clear()
+                deletePensionLottery.clear()
+                isAllSelected = false
+            } else {
+                when (pagerState.currentPage) {
+                    0 -> {
+                        deleteLottery.clear()
+                        lotteryGetContent.itemSnapshotList.items.forEach { content ->
+                            content.lotteryGetNumbers.forEach { number ->
+                                deleteLottery.add(UserRoundId(round = content.round, id = number.id))
+                            }
+                        }
+                    }
+
+                    1 -> {
+                        deletePensionLottery.clear()
+                        pensionLotteryGetContent.itemSnapshotList.items.forEach { content ->
+                            content.pensionLotteryNumbers.forEach { number ->
+                                deletePensionLottery.add(UserRoundId(round = content.round, id = number.id))
+                            }
+                        }
+                    }
+                }
+                isAllSelected = true
+            }
+        },
         onDeleteLotteryCancelClicked = {
             isDeleteMode = false
+            isAllSelected = false
             deleteLottery.clear()
             deletePensionLottery.clear()
         },
@@ -273,6 +316,8 @@ fun MyNumberContent(
     checkedLottery: (userRoundId: UserRoundId) -> Unit,
     checkedPensionLottery: (userRoundId: UserRoundId) -> Unit,
     onDeleteLotteryClicked: () -> Unit,
+    isAllSelected: Boolean,
+    onSelectAllClicked: () -> Unit,
     onDeleteLotteryCancelClicked: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -300,14 +345,27 @@ fun MyNumberContent(
                                 onDeleteLotteryCancelClicked()
                             },
                     )
-                    Text(
-                        text = stringResource(R.string.delete),
-                        color = LottoTheme.colors.lottoError,
-                        modifier =
-                            Modifier.clickable {
-                                onDeleteLotteryClicked()
-                            },
-                    )
+                    Row {
+                        Text(
+                            text =
+                                stringResource(
+                                    if (isAllSelected) R.string.deselect_all else R.string.select_all,
+                                ),
+                            modifier =
+                                Modifier.clickable {
+                                    onSelectAllClicked()
+                                },
+                        )
+                        Spacer(modifier = Modifier.width(20.dp))
+                        Text(
+                            text = stringResource(R.string.delete),
+                            color = LottoTheme.colors.lottoError,
+                            modifier =
+                                Modifier.clickable {
+                                    onDeleteLotteryClicked()
+                                },
+                        )
+                    }
                 }
             } else {
                 TabRow(

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberViewModel.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberViewModel.kt
@@ -3,6 +3,8 @@ package junjange.feature.mynumber
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
+import junjange.core.domain.usecase.DeleteAllLotteryUseCase
+import junjange.core.domain.usecase.DeleteAllPensionLotteryUseCase
 import junjange.core.domain.usecase.DeleteLotteryByRoundAndIdUseCase
 import junjange.core.domain.usecase.DeletePensionLotteryByRoundAndIdUseCase
 import junjange.core.domain.usecase.InsertLotteryUseCase
@@ -33,6 +35,8 @@ class MyNumberViewModel
         private val loadPensionLotteryRoundsUseCase: LoadPensionLotteryRoundsUseCase,
         private val deleteLotteryByRoundAndIdUseCase: DeleteLotteryByRoundAndIdUseCase,
         private val deletePensionLotteryByRoundAndIdUseCase: DeletePensionLotteryByRoundAndIdUseCase,
+        private val deleteAllLotteryUseCase: DeleteAllLotteryUseCase,
+        private val deleteAllPensionLotteryUseCase: DeleteAllPensionLotteryUseCase,
     ) : BaseViewModel() {
         private val _state = MutableStateFlow(State())
         val state: StateFlow<State> = _state.asStateFlow()
@@ -56,6 +60,8 @@ class MyNumberViewModel
                 is Event.PensionLottoTextOfImage -> getPensionLottoTextOfImage(imagePath = event.imagePath)
                 is Event.DeleteLottery -> deleteLottery(userRoundIds = event.userRoundIds)
                 is Event.DeletePensionLottery -> deletePensionLottery(userRoundIds = event.userRoundIds)
+                is Event.DeleteAllLottery -> deleteAllLottery()
+                is Event.DeleteAllPensionLottery -> deleteAllPensionLottery()
                 is Event.ShowDialog -> showDialog(isDialogShowing = event.isDialogShowing)
             }
         }
@@ -189,6 +195,20 @@ class MyNumberViewModel
                 userRoundIds.forEach { (round, id) ->
                     deletePensionLotteryByRoundAndIdUseCase(round = round, id = id)
                 }
+                _effect.send(Effect.PensionLotteryRefresh)
+            }
+        }
+
+        private fun deleteAllLottery() {
+            launch {
+                deleteAllLotteryUseCase()
+                _effect.send(Effect.LotteryRefresh)
+            }
+        }
+
+        private fun deleteAllPensionLottery() {
+            launch {
+                deleteAllPensionLotteryUseCase()
                 _effect.send(Effect.PensionLotteryRefresh)
             }
         }

--- a/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberViewModel.kt
+++ b/feature/mynumber/src/main/java/junjange/feature/mynumber/MyNumberViewModel.kt
@@ -50,8 +50,8 @@ class MyNumberViewModel
                 is Event.PickedImage -> onPickedImage()
                 is Event.LoadLottery -> loadLottery()
                 is Event.LoadPensionLottery -> loadPensionLottery()
-                is Event.InsertLottery -> insertLottery(lottery = event.lottery)
-                is Event.InsertPensionLottery -> insertPensionLottery(pensionLottery = event.pensionLottery)
+                is Event.InsertLotteries -> insertLotteries(lotteries = event.lotteries)
+                is Event.InsertPensionLotteries -> insertPensionLotteries(pensionLotteries = event.pensionLotteries)
                 is Event.LottoTextOfImage -> getLottoTextOfImage(imagePath = event.imagePath)
                 is Event.PensionLottoTextOfImage -> getPensionLottoTextOfImage(imagePath = event.imagePath)
                 is Event.DeleteLottery -> deleteLottery(userRoundIds = event.userRoundIds)
@@ -96,41 +96,53 @@ class MyNumberViewModel
             }
         }
 
-        private fun insertLottery(lottery: List<String>) {
+        private fun insertLotteries(lotteries: List<List<String>>) {
             launch {
                 loading(isLoading = true)
-                insertLotteryUseCase(
-                    firstNum = lottery[0].toInt(),
-                    secondNum = lottery[1].toInt(),
-                    thirdNum = lottery[2].toInt(),
-                    fourthNum = lottery[3].toInt(),
-                    fifthNum = lottery[4].toInt(),
-                    sixthNum = lottery[5].toInt(),
-                ).onSuccess {
+                val results =
+                    lotteries.map { lottery ->
+                        insertLotteryUseCase(
+                            firstNum = lottery[0].toInt(),
+                            secondNum = lottery[1].toInt(),
+                            thirdNum = lottery[2].toInt(),
+                            fourthNum = lottery[3].toInt(),
+                            fifthNum = lottery[4].toInt(),
+                            sixthNum = lottery[5].toInt(),
+                        )
+                    }
+                if (results.any { it.isSuccess }) {
                     _effect.send(Effect.LotteryRefresh)
+                }
+                if (results.all { it.isSuccess }) {
                     _effect.send(Effect.ShowMessage(MyNumberMessage.LOTTERY_INSERT_SUCCESS))
-                }.onFailure {
+                } else {
                     _effect.send(Effect.ShowMessage(MyNumberMessage.LOTTERY_INSERT_FAILED))
                 }
                 loading(false)
             }
         }
 
-        private fun insertPensionLottery(pensionLottery: List<String>) {
+        private fun insertPensionLotteries(pensionLotteries: List<List<String>>) {
             launch {
                 loading(isLoading = true)
-                insertPensionLotteryUseCase(
-                    group = pensionLottery[0].toInt(),
-                    firstNum = pensionLottery[1].toInt(),
-                    secondNum = pensionLottery[2].toInt(),
-                    thirdNum = pensionLottery[3].toInt(),
-                    fourthNum = pensionLottery[4].toInt(),
-                    fifthNum = pensionLottery[5].toInt(),
-                    sixthNum = pensionLottery[6].toInt(),
-                ).onSuccess {
+                val results =
+                    pensionLotteries.map { pensionLottery ->
+                        insertPensionLotteryUseCase(
+                            group = pensionLottery[0].toInt(),
+                            firstNum = pensionLottery[1].toInt(),
+                            secondNum = pensionLottery[2].toInt(),
+                            thirdNum = pensionLottery[3].toInt(),
+                            fourthNum = pensionLottery[4].toInt(),
+                            fifthNum = pensionLottery[5].toInt(),
+                            sixthNum = pensionLottery[6].toInt(),
+                        )
+                    }
+                if (results.any { it.isSuccess }) {
                     _effect.send(Effect.PensionLotteryRefresh)
+                }
+                if (results.all { it.isSuccess }) {
                     _effect.send(Effect.ShowMessage(MyNumberMessage.PENSION_LOTTERY_INSERT_SUCCESS))
-                }.onFailure {
+                } else {
                     _effect.send(Effect.ShowMessage(MyNumberMessage.PENSION_LOTTERY_INSERT_FAILED))
                 }
                 loading(false)
@@ -149,9 +161,7 @@ class MyNumberViewModel
             val lottoNumbers = text.extractLottoNumbers()
 
             if (lottoNumbers.isValidLottoNumbers()) {
-                lottoNumbers.forEach { lottoNumber ->
-                    insertLottery(lottery = lottoNumber)
-                }
+                insertLotteries(lotteries = lottoNumbers)
             }
         }
 
@@ -161,9 +171,7 @@ class MyNumberViewModel
             val lottoNumbers = text.extractPensionLottoNumbers()
 
             if (lottoNumbers.isValidPensionLottoNumbers()) {
-                lottoNumbers.forEach { lottoNumber ->
-                    insertPensionLottery(pensionLottery = lottoNumber)
-                }
+                insertPensionLotteries(pensionLotteries = lottoNumbers)
             }
         }
 

--- a/feature/mynumber/src/main/res/values/strings.xml
+++ b/feature/mynumber/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="done">완료</string>
     <string name="empty_delete_list">삭제할 번호가 없어요</string>
     <string name="delete">삭제</string>
+    <string name="select_all">전체 선택</string>
+    <string name="deselect_all">선택 해제</string>
 
     <string name="lotto_number_submitted">로또 번호가 추가되었습니다.</string>
     <string name="lotto_duplicate_error">로또 번호가 중복되었습니다!</string>


### PR DESCRIPTION
resolved: #129 

# 작업 내용
- 번호 등록 시 여러 번호를 한 번에 추가할 수 있도록 개선
  - 번호 입력 바텀시트에 "번호 추가" 버튼 추가 (추가 개수 제한 없음, 개별 행 삭제 가능)
  - 로또 6/45, 연금복권 720+ 모두 지원
  - 여러 번호 저장 시 목록 새로고침/스낵바가 1회만 발생하도록 배치 처리 (OCR 등록 경로도 동일 적용)
- 삭제 모드에 전체 선택 기능 추가
  - 상단바에 "전체 선택 / 선택 해제" 토글 버튼 추가
  - 개별 체크박스 조작 시 전체 선택 상태 자동 해제
  - 전체 선택 상태로 삭제 시 deleteAll 쿼리로 처리하여 페이징으로 로드되지 않은 번호까지 모두 삭제
